### PR TITLE
Changes after XStream commit support

### DIFF
--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MetadataIT.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MetadataIT.java
@@ -6,11 +6,13 @@
 package io.debezium.connector.mysql;
 
 import java.sql.SQLException;
+
 import java.sql.Types;
 
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
@@ -57,7 +59,7 @@ public class MetadataIT implements Testing {
             assertThat(person.columnWithName("name").typeName()).isEqualTo("VARCHAR");
             assertThat(person.columnWithName("name").jdbcType()).isEqualTo(Types.VARCHAR);
             assertThat(person.columnWithName("name").length()).isEqualTo(255);
-            assertThat(person.columnWithName("name").scale()).isEqualTo(0);
+            assertFalse(person.columnWithName("name").scale().isPresent());
             assertThat(person.columnWithName("name").position()).isEqualTo(1);
             assertThat(person.columnWithName("name").isAutoIncremented()).isFalse();
             assertThat(person.columnWithName("name").isGenerated()).isFalse();
@@ -66,7 +68,7 @@ public class MetadataIT implements Testing {
             assertThat(person.columnWithName("birthdate").typeName()).isEqualTo("DATE");
             assertThat(person.columnWithName("birthdate").jdbcType()).isEqualTo(Types.DATE);
             assertThat(person.columnWithName("birthdate").length()).isEqualTo(10);
-            assertThat(person.columnWithName("birthdate").scale()).isEqualTo(0);
+            assertFalse(person.columnWithName("birthdate").scale().isPresent());
             assertThat(person.columnWithName("birthdate").position()).isEqualTo(2);
             assertThat(person.columnWithName("birthdate").isAutoIncremented()).isFalse();
             assertThat(person.columnWithName("birthdate").isGenerated()).isFalse();
@@ -75,7 +77,7 @@ public class MetadataIT implements Testing {
             assertThat(person.columnWithName("age").typeName()).isEqualTo("INT");
             assertThat(person.columnWithName("age").jdbcType()).isEqualTo(Types.INTEGER);
             assertThat(person.columnWithName("age").length()).isEqualTo(10);
-            assertThat(person.columnWithName("age").scale()).isEqualTo(0);
+            assertThat(person.columnWithName("age").scale().get()).isEqualTo(0);
             assertThat(person.columnWithName("age").position()).isEqualTo(3);
             assertThat(person.columnWithName("age").isAutoIncremented()).isFalse();
             assertThat(person.columnWithName("age").isGenerated()).isFalse();
@@ -84,7 +86,7 @@ public class MetadataIT implements Testing {
             assertThat(person.columnWithName("salary").typeName()).isEqualTo("DECIMAL");
             assertThat(person.columnWithName("salary").jdbcType()).isEqualTo(Types.DECIMAL);
             assertThat(person.columnWithName("salary").length()).isEqualTo(5);
-            assertThat(person.columnWithName("salary").scale()).isEqualTo(2);
+            assertThat(person.columnWithName("salary").scale().get()).isEqualTo(2);
             assertThat(person.columnWithName("salary").position()).isEqualTo(4);
             assertThat(person.columnWithName("salary").isAutoIncremented()).isFalse();
             assertThat(person.columnWithName("salary").isGenerated()).isFalse();
@@ -93,7 +95,7 @@ public class MetadataIT implements Testing {
             assertThat(person.columnWithName("bitStr").typeName()).isEqualTo("BIT");
             assertThat(person.columnWithName("bitStr").jdbcType()).isEqualTo(Types.BIT);
             assertThat(person.columnWithName("bitStr").length()).isEqualTo(18);
-            assertThat(person.columnWithName("bitStr").scale()).isEqualTo(0);
+            assertFalse(person.columnWithName("bitStr").scale().isPresent());
             assertThat(person.columnWithName("bitStr").position()).isEqualTo(5);
             assertThat(person.columnWithName("bitStr").isAutoIncremented()).isFalse();
             assertThat(person.columnWithName("bitStr").isGenerated()).isFalse();
@@ -119,7 +121,7 @@ public class MetadataIT implements Testing {
             assertThat(product.columnWithName("id").typeName()).isEqualTo("INT");
             assertThat(product.columnWithName("id").jdbcType()).isEqualTo(Types.INTEGER);
             assertThat(product.columnWithName("id").length()).isEqualTo(10);
-            assertThat(product.columnWithName("id").scale()).isEqualTo(0);
+            assertThat(product.columnWithName("id").scale().get()).isEqualTo(0);
             assertThat(product.columnWithName("id").position()).isEqualTo(1);
             assertThat(product.columnWithName("id").isAutoIncremented()).isTrue();
             assertThat(product.columnWithName("id").isGenerated()).isFalse();
@@ -128,7 +130,7 @@ public class MetadataIT implements Testing {
             assertThat(product.columnWithName("createdByDate").typeName()).isEqualTo("DATETIME");
             assertThat(product.columnWithName("createdByDate").jdbcType()).isEqualTo(Types.TIMESTAMP);
             assertThat(product.columnWithName("createdByDate").length()).isEqualTo(19);
-            assertThat(product.columnWithName("createdByDate").scale()).isEqualTo(0);
+            assertFalse(product.columnWithName("createdByDate").scale().isPresent());
             assertThat(product.columnWithName("createdByDate").position()).isEqualTo(2);
             assertThat(product.columnWithName("createdByDate").isAutoIncremented()).isFalse();
             assertThat(product.columnWithName("createdByDate").isGenerated()).isFalse();
@@ -137,7 +139,7 @@ public class MetadataIT implements Testing {
             assertThat(product.columnWithName("modifiedDate").typeName()).isEqualTo("DATETIME");
             assertThat(product.columnWithName("modifiedDate").jdbcType()).isEqualTo(Types.TIMESTAMP);
             assertThat(product.columnWithName("modifiedDate").length()).isEqualTo(19);
-            assertThat(product.columnWithName("modifiedDate").scale()).isEqualTo(0);
+            assertFalse(product.columnWithName("modifiedDate").scale().isPresent());
             assertThat(product.columnWithName("modifiedDate").position()).isEqualTo(3);
             assertThat(product.columnWithName("modifiedDate").isAutoIncremented()).isFalse();
             assertThat(product.columnWithName("modifiedDate").isGenerated()).isFalse();
@@ -163,7 +165,7 @@ public class MetadataIT implements Testing {
             assertThat(purchased.columnWithName("purchaser").typeName()).isEqualTo("VARCHAR");
             assertThat(purchased.columnWithName("purchaser").jdbcType()).isEqualTo(Types.VARCHAR);
             assertThat(purchased.columnWithName("purchaser").length()).isEqualTo(255);
-            assertThat(purchased.columnWithName("purchaser").scale()).isEqualTo(0);
+            assertFalse(purchased.columnWithName("purchaser").scale().isPresent());
             assertThat(purchased.columnWithName("purchaser").position()).isEqualTo(1);
             assertThat(purchased.columnWithName("purchaser").isAutoIncremented()).isFalse();
             assertThat(purchased.columnWithName("purchaser").isGenerated()).isFalse();
@@ -172,7 +174,7 @@ public class MetadataIT implements Testing {
             assertThat(purchased.columnWithName("productId").typeName()).isEqualTo("INT");
             assertThat(purchased.columnWithName("productId").jdbcType()).isEqualTo(Types.INTEGER);
             assertThat(purchased.columnWithName("productId").length()).isEqualTo(10);
-            assertThat(purchased.columnWithName("productId").scale()).isEqualTo(0);
+            assertThat(purchased.columnWithName("productId").scale().isPresent());
             assertThat(purchased.columnWithName("productId").position()).isEqualTo(2);
             assertThat(purchased.columnWithName("productId").isAutoIncremented()).isFalse();
             assertThat(purchased.columnWithName("productId").isGenerated()).isFalse();
@@ -181,7 +183,7 @@ public class MetadataIT implements Testing {
             assertThat(purchased.columnWithName("purchaseDate").typeName()).isEqualTo("DATETIME");
             assertThat(purchased.columnWithName("purchaseDate").jdbcType()).isEqualTo(Types.TIMESTAMP);
             assertThat(purchased.columnWithName("purchaseDate").length()).isEqualTo(19);
-            assertThat(purchased.columnWithName("purchaseDate").scale()).isEqualTo(0);
+            assertFalse(purchased.columnWithName("purchaseDate").scale().isPresent());
             assertThat(purchased.columnWithName("purchaseDate").position()).isEqualTo(3);
             assertThat(purchased.columnWithName("purchaseDate").isAutoIncremented()).isFalse();
             assertThat(purchased.columnWithName("purchaseDate").isGenerated()).isFalse();

--- a/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
+++ b/debezium-connector-mysql/src/test/java/io/debezium/connector/mysql/MySqlDdlParserTest.java
@@ -6,6 +6,7 @@
 package io.debezium.connector.mysql;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -1583,7 +1584,7 @@ public class MySqlDdlParserTest {
         assertThat(column.jdbcType()).isEqualTo(jdbcType);
         assertThat(column.length()).isEqualTo(length);
         assertThat(column.charsetName()).isEqualTo(charsetName);
-        assertThat(column.scale()).isEqualTo(-1);
+        assertFalse(column.scale().isPresent());
         assertThat(column.isOptional()).isEqualTo(optional);
         assertThat(column.isGenerated()).isFalse();
         assertThat(column.isAutoIncremented()).isFalse();
@@ -1596,7 +1597,12 @@ public class MySqlDdlParserTest {
         assertThat(column.typeName()).isEqualTo(typeName);
         assertThat(column.jdbcType()).isEqualTo(jdbcType);
         assertThat(column.length()).isEqualTo(length);
-        assertThat(column.scale()).isEqualTo(scale);
+        if (scale == Column.UNSET_INT_VALUE) {
+            assertFalse(column.scale().isPresent());
+        }
+        else {
+            assertThat(column.scale().get()).isEqualTo(scale);
+        }
         assertThat(column.isOptional()).isEqualTo(optional);
         assertThat(column.isGenerated()).isEqualTo(generated);
         assertThat(column.isAutoIncremented()).isEqualTo(autoIncremented);

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnection.java
@@ -11,6 +11,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -107,8 +108,8 @@ public class OracleConnection extends JdbcConnection {
                 if (column.jdbcType() == Types.TIMESTAMP) {
                     editor.addColumn(
                             column.edit()
-                                .length(column.scale())
-                                .scale(-1)
+                                .length(column.scale().orElse(Column.UNSET_INT_VALUE))
+                                .scale(Optional.empty())
                                 .create()
                             );
                 }

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleConnectorTask.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -160,6 +161,8 @@ public class OracleConnectorTask extends BaseSourceTask {
         catch (InterruptedException e) {
             Thread.interrupted();
             LOGGER.error("Interrupted while stopping coordinator", e);
+            // XStream code can end in SIGSEGV so fail the task instead of JVM crash
+            throw new ConnectException("Interrupted while stopping coordinator, failing the task");
         }
 
         try {

--- a/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSource.java
+++ b/debezium-connector-oracle/src/main/java/io/debezium/connector/oracle/OracleStreamingChangeEventSource.java
@@ -85,7 +85,9 @@ public class OracleStreamingChangeEventSource implements StreamingChangeEventSou
     public void commitOffset(Map<String, ?> offset) {
         if (xsOut != null) {
             try {
-                xsOut.setProcessedLowWatermark(convertScnToPosition((long) offset.get(SourceInfo.SCN_KEY)), XStreamOut.DEFAULT_MODE);
+                LOGGER.debug("Recording offsets to Oracle");
+                xsOut.setProcessedLowWatermark(convertScnToPosition((Long) offset.get(SourceInfo.SCN_KEY)), XStreamOut.DEFAULT_MODE);
+                LOGGER.trace("Offsets recorded to Oracle");
             }
             catch (StreamsException e) {
                 throw new RuntimeException("Couldn't set processed low watermark", e);

--- a/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDdlParserTest.java
+++ b/debezium-connector-oracle/src/test/java/io/debezium/connector/oracle/OracleDdlParserTest.java
@@ -61,7 +61,7 @@ public class OracleDdlParserTest {
         assertThat(score.jdbcType()).isEqualTo(Types.NUMERIC);
         assertThat(score.typeName()).isEqualTo("NUMBER");
         assertThat(score.length()).isEqualTo(6);
-        assertThat(score.scale()).isEqualTo(2);
+        assertThat(score.scale().get()).isEqualTo(2);
 
         assertThat(table.columns()).hasSize(4);
         assertThat(table.isPrimaryKeyColumn("ID"));

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/PostgresValueConverter.java
@@ -123,7 +123,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
             case PgOid.POINT:
                 return Point.builder();
             case PgOid.MONEY:
-                return Decimal.builder(column.scale());
+                return Decimal.builder(column.scale().get());
             case PgOid.NUMERIC:
                 return numericSchema(column);
             case PgOid.BYTEA:
@@ -199,7 +199,7 @@ public class PostgresValueConverter extends JdbcValueConverters {
         if (decimalMode == DecimalMode.PRECISE && isVariableScaleDecimal(column)) {
             return VariableScaleDecimal.builder();
         }
-        return SpecialValueDecimal.builder(decimalMode, column.scale());
+        return SpecialValueDecimal.builder(decimalMode, column.scale().get());
     }
 
     @Override
@@ -331,8 +331,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
         }
 
         newDecimal = value.getDecimalValue().get();
-        if (column.scale() > newDecimal.scale()) {
-          newDecimal = newDecimal.setScale(column.scale());
+        if (column.scale().get() > newDecimal.scale()) {
+          newDecimal = newDecimal.setScale(column.scale().get());
         }
 
         if (isVariableScaleDecimal(column) && mode == DecimalMode.PRECISE) {
@@ -600,8 +600,8 @@ public class PostgresValueConverter extends JdbcValueConverters {
     }
 
     private boolean isVariableScaleDecimal(final Column column) {
-        return (column.scale() == 0 && column.length() == VARIABLE_SCALE_DECIMAL_LENGTH)
-                || (column.scale() == -1 && column.length() == -1);
+        return (column.scale().isPresent() && column.scale().get() == 0 && column.length() == VARIABLE_SCALE_DECIMAL_LENGTH)
+                || (!column.scale().isPresent() && column.length() == -1);
     }
 
     public static Optional<SpecialValueDecimal> toSpecialValue(String value) {

--- a/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
+++ b/debezium-connector-postgres/src/main/java/io/debezium/connector/postgresql/RecordsStreamProducer.java
@@ -465,7 +465,7 @@ public class RecordsStreamProducer extends RecordsProducer {
                                     incomingLength);
                         return true;
                     }
-                    final int localScale = column.scale();
+                    final int localScale = column.scale().get();
                     final int incomingScale = message.getTypeMetadata().getScale();
                     if (localScale != incomingScale) {
                         logger.info("detected new scale for column '{}', old scale was {}, new scale is {}; refreshing table schema", columnName, localScale,

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcConnection.java
@@ -796,7 +796,9 @@ public class JdbcConnection implements AutoCloseable {
                         column.jdbcType(rs.getInt(5));
                         column.type(rs.getString(6));
                         column.length(rs.getInt(7));
-                        column.scale(rs.getInt(9));
+                        if (rs.getObject(9) != null) {
+                            column.scale(rs.getInt(9));
+                        }
                         column.optional(isNullable(rs.getInt(11)));
                         column.position(rs.getInt(17));
                         column.autoIncremented("YES".equalsIgnoreCase(rs.getString(23)));

--- a/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
+++ b/debezium-core/src/main/java/io/debezium/jdbc/JdbcValueConverters.java
@@ -162,7 +162,7 @@ public class JdbcValueConverters implements ValueConverterProvider {
                 return SchemaBuilder.float64();
             case Types.NUMERIC:
             case Types.DECIMAL:
-                return SpecialValueDecimal.builder(decimalMode, column.scale());
+                return SpecialValueDecimal.builder(decimalMode, column.scale().get());
 
                 // Fixed-length string values
             case Types.CHAR:

--- a/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
+++ b/debezium-core/src/main/java/io/debezium/pipeline/ChangeEventSourceCoordinator.java
@@ -35,7 +35,7 @@ public class ChangeEventSourceCoordinator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ChangeEventSourceCoordinator.class);
 
-    private static final Duration SHUTDOWN_WAIT_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration SHUTDOWN_WAIT_TIMEOUT = Duration.ofSeconds(90);
 
     private final OffsetContext previousOffset;
     private final ErrorHandler errorHandler;
@@ -91,6 +91,7 @@ public class ChangeEventSourceCoordinator {
         running = false;
 
         executor.shutdown();
+        Thread.interrupted();
         boolean isShutdown = executor.awaitTermination(SHUTDOWN_WAIT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
         if (!isShutdown) {

--- a/debezium-core/src/main/java/io/debezium/relational/Column.java
+++ b/debezium-core/src/main/java/io/debezium/relational/Column.java
@@ -6,6 +6,7 @@
 package io.debezium.relational;
 
 import java.sql.Types;
+import java.util.Optional;
 
 import io.debezium.annotation.Immutable;
 
@@ -90,9 +91,9 @@ public interface Column extends Comparable<Column> {
     /**
      * Get the scale of the column.
      *
-     * @return the scale, or -1 if the scale does not apply to this type
+     * @return the scale if it applies to this type
      */
-    int scale();
+    Optional<Integer> scale();
 
     /**
      * Determine whether this column is optional.

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnEditor.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnEditor.java
@@ -6,6 +6,7 @@
 package io.debezium.relational;
 
 import java.sql.Types;
+import java.util.Optional;
 
 import io.debezium.annotation.NotThreadSafe;
 
@@ -87,9 +88,9 @@ public interface ColumnEditor extends Comparable<Column> {
     /**
      * Get the scale of the column.
      * 
-     * @return the scale, or -1 if the scale does not apply to this type
+     * @return the scale if present
      */
-    int scale();
+    Optional<Integer> scale();
 
     /**
      * Determine whether this column is optional.
@@ -181,10 +182,18 @@ public interface ColumnEditor extends Comparable<Column> {
     /**
      * Set the scale of the column.
      * 
-     * @param scale the scale, or -1 if the scale does not apply to this type
+     * @param scale the scale
      * @return this editor so callers can chain methods together
      */
     ColumnEditor scale(int scale);
+
+    /**
+     * Set the scale of the column.
+     *
+     * @param scale the scale, or empty() if the scale does not apply to this type
+     * @return this editor so callers can chain methods together
+     */
+    ColumnEditor scale(Optional<Integer> scale);
 
     /**
      * Set whether the column's values are optional (e.g., can contain nulls).

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnEditorImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnEditorImpl.java
@@ -6,6 +6,7 @@
 package io.debezium.relational;
 
 import java.sql.Types;
+import java.util.Optional;
 
 final class ColumnEditorImpl implements ColumnEditor {
 
@@ -17,7 +18,7 @@ final class ColumnEditorImpl implements ColumnEditor {
     private String charsetName;
     private String tableCharsetName;
     private int length = Column.UNSET_INT_VALUE;
-    private int scale = Column.UNSET_INT_VALUE;
+    private Optional<Integer> scale = Optional.empty();
     private int position = 1;
     private boolean optional = true;
     private boolean autoIncremented = false;
@@ -67,7 +68,7 @@ final class ColumnEditorImpl implements ColumnEditor {
     }
 
     @Override
-    public int scale() {
+    public Optional<Integer> scale() {
         return scale;
     }
 
@@ -144,7 +145,11 @@ final class ColumnEditorImpl implements ColumnEditor {
 
     @Override
     public ColumnEditorImpl scale(int scale) {
-        assert scale >= -1;
+        return scale(Optional.of(scale));
+    }
+
+    @Override
+    public ColumnEditorImpl scale(Optional<Integer> scale) {
         this.scale = scale;
         return this;
     }

--- a/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
+++ b/debezium-core/src/main/java/io/debezium/relational/ColumnImpl.java
@@ -5,6 +5,8 @@
  */
 package io.debezium.relational;
 
+import java.util.Optional;
+
 import io.debezium.util.Strings;
 
 final class ColumnImpl implements Column, Comparable<Column> {
@@ -16,13 +18,13 @@ final class ColumnImpl implements Column, Comparable<Column> {
     private final String typeExpression;
     private final String charsetName;
     private final int length;
-    private final int scale;
+    private final Optional<Integer> scale;
     private final boolean optional;
     private final boolean autoIncremented;
     private final boolean generated;
 
     protected ColumnImpl(String columnName, int position, int jdbcType, int nativeType, String typeName, String typeExpression,
-                         String charsetName, String defaultCharsetName, int columnLength, int columnScale,
+                         String charsetName, String defaultCharsetName, int columnLength, Optional<Integer> columnScale,
                          boolean optional, boolean autoIncremented, boolean generated) {
         this.name = columnName;
         this.position = position;
@@ -41,7 +43,6 @@ final class ColumnImpl implements Column, Comparable<Column> {
         this.optional = optional;
         this.autoIncremented = autoIncremented;
         this.generated = generated;
-        assert this.scale >= -1;
         assert this.length >= -1;
     }
 
@@ -86,7 +87,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
     }
 
     @Override
-    public int scale() {
+    public Optional<Integer> scale() {
         return scale;
     }
 
@@ -136,9 +137,7 @@ final class ColumnImpl implements Column, Comparable<Column> {
         sb.append(" ").append(typeName);
         if (length >= 0) {
             sb.append('(').append(length);
-            if (scale >= 0) {
-                sb.append(',').append(scale);
-            }
+            scale.ifPresent(s -> sb.append(',').append(s));
             sb.append(')');
         }
         if (charsetName != null && !charsetName.isEmpty()) {

--- a/debezium-core/src/main/java/io/debezium/relational/history/TableChanges.java
+++ b/debezium-core/src/main/java/io/debezium/relational/history/TableChanges.java
@@ -203,9 +203,7 @@ public class TableChanges implements Iterable<TableChange> {
                 document.setNumber("length", column.length());
             }
 
-            if (column.scale() != Column.UNSET_INT_VALUE) {
-                document.setNumber("scale", column.scale());
-            }
+            column.scale().ifPresent(s -> document.setNumber("scale", s));
 
             document.setNumber("position", column.position());
             document.setBoolean("optional", column.isOptional());

--- a/debezium-core/src/test/java/io/debezium/relational/ColumnEditorTest.java
+++ b/debezium-core/src/test/java/io/debezium/relational/ColumnEditorTest.java
@@ -5,12 +5,13 @@
  */
 package io.debezium.relational;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.sql.Types;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 public class ColumnEditorTest {
 
@@ -43,7 +44,7 @@ public class ColumnEditorTest {
         assertThat(column.typeName()).isEqualTo("NUMBER");
         assertThat(column.jdbcType()).isEqualTo(Types.DOUBLE);
         assertThat(column.length()).isEqualTo(5);
-        assertThat(column.scale()).isEqualTo(2);
+        assertThat(column.scale().get()).isEqualTo(2);
         assertThat(column.position()).isEqualTo(4);
         assertThat(column.isOptional()).isTrue();
         assertThat(column.isAutoIncremented()).isTrue();
@@ -57,7 +58,7 @@ public class ColumnEditorTest {
         assertThat(column.typeName()).isNull();
         assertThat(column.jdbcType()).isEqualTo(Types.INTEGER);
         assertThat(column.length()).isEqualTo(-1);
-        assertThat(column.scale()).isEqualTo(-1);
+        Assert.assertFalse(column.scale().isPresent());
         assertThat(column.position()).isEqualTo(1);
         assertThat(column.isOptional()).isTrue();
         assertThat(column.isAutoIncremented()).isFalse();

--- a/debezium-core/src/test/java/io/debezium/relational/ddl/DdlParserSql2003Test.java
+++ b/debezium-core/src/test/java/io/debezium/relational/ddl/DdlParserSql2003Test.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.fest.assertions.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
 
 import io.debezium.relational.Column;
 import io.debezium.relational.Table;
@@ -83,7 +84,12 @@ public class DdlParserSql2003Test {
         assertThat(column.typeName()).isEqualTo(typeName);
         assertThat(column.jdbcType()).isEqualTo(jdbcType);
         assertThat(column.length()).isEqualTo(length);
-        assertThat(column.scale()).isEqualTo(scale);
+        if (scale == Column.UNSET_INT_VALUE) {
+            assertFalse(column.scale().isPresent());
+        }
+        else {
+            assertThat(column.scale().get()).isEqualTo(scale);
+        }
         assertThat(column.isOptional()).isEqualTo(optional);
         assertThat(column.isGenerated()).isEqualTo(generated);
         assertThat(column.isAutoIncremented()).isEqualTo(autoIncremented);

--- a/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
+++ b/debezium-embedded/src/test/java/io/debezium/embedded/AbstractConnectorTest.java
@@ -133,7 +133,8 @@ public abstract class AbstractConnectorTest implements Testing {
             if (engine != null && engine.isRunning()) {
                 engine.stop();
                 try {
-                    engine.await(8, TimeUnit.SECONDS);
+                    // Oracle connector needs longer time to complete shutdown
+                    engine.await(60, TimeUnit.SECONDS);
                 } catch (InterruptedException e) {
                     Thread.interrupted();
                 }


### PR DESCRIPTION
Three changes made
 - Oracle connector is on the slow side so it was necessary to tune the timeouts a little bit to make the shutdown stable
 - Oracle supports negative number sin precision so we cannot use `-1` as an indicator of empty precision. There is no test added for negative precision as there is a bug in grammar - engforces positiove precision
 - When an interrupt is thrown during coordinator shutdown and XStream operation is in progress it could happen that when connecotr `stop()` operation was kept in progress that JVM crashed with `SIGSEGV`.  Now when coordinator is not stopped in time then task is failed